### PR TITLE
Ensure the thumbnail box always has an image

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,7 +49,9 @@ function generateInfoBox(accentColor, text, thumbnailURL) {
         accessory: {
           type: ComponentType.Thumbnail,
           media: {
-            url: thumbnailURL,
+            // FIXME: Use different default images for different kinds of info box.
+            //        Probably populate that when loading the Rebrickable JSON.
+            url: thumbnailURL || "https://rebrickable.com/static/img/nil_mf.jpg",
           }
         },
       }]


### PR DESCRIPTION
`url` is a required field for the Discord Thumbnail component. If Rebrickable didn't give us an image URL, and we blindly pass `undefined` here, then Discord complains and we crash.

The crashing is because we don't handle exceptions in async functions properly - that's a separate fix that's very necessary. But this solves the immediate issue.